### PR TITLE
Add caching service for Firestore

### DIFF
--- a/lib/src/screens/auth/login_screen.dart
+++ b/lib/src/screens/auth/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:solutions_rent_car/src/utils/cache_service.dart';
 import 'package:solutions_rent_car/src/screens/home/ClientHomeScreen.dart';
 import 'package:solutions_rent_car/src/screens/home/SellerHomeScreen.dart';
 import 'package:flutter/foundation.dart'; // asegúrate de tener esto
@@ -510,11 +511,10 @@ class _LoginScreenState extends State<LoginScreen> {
         }
 
         // Obtener el rol del usuario desde Firestore
-        final documentoUsuario =
-            await FirebaseFirestore.instance
-                .collection('usuarios')
-                .doc(userId)
-                .get();
+        final documentoUsuario = await CacheService.getDocument(
+          'usuarios',
+          userId,
+        );
 
         if (!documentoUsuario.exists) {
           throw Exception('El usuario no existe en la base de datos');

--- a/lib/src/screens/rentas/ConfirmacionReservaScreen.dart
+++ b/lib/src/screens/rentas/ConfirmacionReservaScreen.dart
@@ -6,6 +6,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:solutions_rent_car/src/screens/home/ClientHomeScreen.dart';
+import 'package:solutions_rent_car/src/utils/cache_service.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'dart:math';
 
@@ -64,11 +65,11 @@ class _ConfirmacionReservaScreenState extends State<ConfirmacionReservaScreen> {
       final String idVehiculo = widget.vehiculoData['idVehiculo'];
 
       if (idVehiculo.isNotEmpty) {
-        final snapshot =
-            await FirebaseFirestore.instance
-                .collection('vehiculos')
-                .where('idVehiculo', isEqualTo: idVehiculo)
-                .get();
+        final snapshot = await CacheService.queryCollection(
+          'vehiculos',
+          'idVehiculo',
+          idVehiculo,
+        );
 
         if (snapshot.docs.isNotEmpty) {
           // Actualizamos con los datos más recientes

--- a/lib/src/utils/cache_service.dart
+++ b/lib/src/utils/cache_service.dart
@@ -1,0 +1,77 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class _CacheEntry<T> {
+  final T data;
+  final DateTime expiry;
+  _CacheEntry(this.data, this.expiry);
+  bool get isValid => DateTime.now().isBefore(expiry);
+}
+
+class CacheService {
+  static final Map<String, _CacheEntry<dynamic>> _cache = {};
+
+  static T? _get<T>(String key) {
+    final entry = _cache[key];
+    if (entry != null && entry.isValid) {
+      return entry.data as T;
+    }
+    _cache.remove(key);
+    return null;
+  }
+
+  static void _set<T>(String key, T data, Duration duration) {
+    _cache[key] = _CacheEntry<T>(data, DateTime.now().add(duration));
+  }
+
+  static Future<DocumentSnapshot<Map<String, dynamic>>> getDocument(
+    String collection,
+    String docId, {
+    Duration duration = const Duration(minutes: 10),
+  }) async {
+    final key = 'doc:$collection/$docId';
+    final cached = _get<DocumentSnapshot<Map<String, dynamic>>>(key);
+    if (cached != null) return cached;
+
+    final doc = await FirebaseFirestore.instance
+        .collection(collection)
+        .doc(docId)
+        .get();
+    _set(key, doc, duration);
+    return doc;
+  }
+
+  static Future<QuerySnapshot<Map<String, dynamic>>> getCollection(
+    String collection, {
+    Duration duration = const Duration(minutes: 10),
+  }) async {
+    final key = 'col:$collection';
+    final cached = _get<QuerySnapshot<Map<String, dynamic>>>(key);
+    if (cached != null) return cached;
+
+    final snapshot =
+        await FirebaseFirestore.instance.collection(collection).get();
+    _set(key, snapshot, duration);
+    return snapshot;
+  }
+
+  static Future<QuerySnapshot<Map<String, dynamic>>> queryCollection(
+    String collection,
+    String field,
+    dynamic value, {
+    Duration duration = const Duration(minutes: 10),
+  }) async {
+    final key = 'qry:$collection:$field:$value';
+    final cached = _get<QuerySnapshot<Map<String, dynamic>>>(key);
+    if (cached != null) return cached;
+
+    final snapshot = await FirebaseFirestore.instance
+        .collection(collection)
+        .where(field, isEqualTo: value)
+        .get();
+    _set(key, snapshot, duration);
+    return snapshot;
+  }
+
+  static void invalidate(String key) => _cache.remove(key);
+  static void clear() => _cache.clear();
+}

--- a/lib/src/vehiculos/AgregarNuevoVehiculoScreen.dart
+++ b/lib/src/vehiculos/AgregarNuevoVehiculoScreen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:solutions_rent_car/src/utils/cache_service.dart';
 import 'package:shimmer/shimmer.dart';
 
 class AgregarNuevoVehiculoScreen extends StatefulWidget {
@@ -61,7 +62,7 @@ class _AgregarNuevoVehiculoScreenState
 
   Future<void> cargarMarcasYModelos() async {
     final snapshot =
-        await FirebaseFirestore.instance.collection('marcas').get();
+        await CacheService.getCollection('marcas');
 
     if (snapshot.docs.isEmpty) {
       setState(() => _isLoading = false);

--- a/lib/src/vehiculos/ClienteDetalleVehiculoScreen.dart
+++ b/lib/src/vehiculos/ClienteDetalleVehiculoScreen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
+import 'package:solutions_rent_car/src/utils/cache_service.dart';
 import 'package:solutions_rent_car/src/screens/rentas/SeleccionFechaHoraScreen.dart';
 
 class ClienteDetalleVehiculoScreen extends StatefulWidget {
@@ -57,11 +58,10 @@ class _ClienteDetalleVehiculoScreenState
   Future<void> _loadUserData() async {
     final user = FirebaseAuth.instance.currentUser;
     if (user != null) {
-      final doc =
-          await FirebaseFirestore.instance
-              .collection('usuarios')
-              .doc(user.uid)
-              .get();
+      final doc = await CacheService.getDocument(
+        'usuarios',
+        user.uid,
+      );
       if (doc.exists) {
         setState(() {
           nombreCliente = doc['name'] ?? '';
@@ -72,11 +72,10 @@ class _ClienteDetalleVehiculoScreenState
   }
 
   Future<void> _loadVehiculoData() async {
-    final doc =
-        await FirebaseFirestore.instance
-            .collection('vehiculos')
-            .doc(widget.idVehiculo)
-            .get();
+    final doc = await CacheService.getDocument(
+      'vehiculos',
+      widget.idVehiculo,
+    );
 
     if (!doc.exists) {
       setState(() => vehiculoNoEncontrado = true);

--- a/lib/src/vehiculos/Proveedor/VehicleScreen.dart
+++ b/lib/src/vehiculos/Proveedor/VehicleScreen.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:solutions_rent_car/src/utils/cache_service.dart';
 
 class VehicleScreen extends StatelessWidget {
   final String idVehiculo;
@@ -17,11 +18,10 @@ class VehicleScreen extends StatelessWidget {
         elevation: 0,
       ),
       body: FutureBuilder<DocumentSnapshot>(
-        future:
-            FirebaseFirestore.instance
-                .collection('vehiculos')
-                .doc(idVehiculo)
-                .get(),
+        future: CacheService.getDocument(
+          'vehiculos',
+          idVehiculo,
+        ),
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());


### PR DESCRIPTION
## Summary
- introduce `CacheService` for in-memory caching of Firestore queries
- use the cache to load brands on new vehicle screen
- retrieve user and vehicle data with cache on detail screens
- reduce database lookups in login, vehicle view and reservation confirmation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849b831f8448327b5241a7fcbaeb7c1