### PR TITLE
Implement provider notifications

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:solutions_rent_car/firebase_options.dart';
 import 'package:solutions_rent_car/src/screens/auth/register_screen.dart';
 import 'package:solutions_rent_car/src/screens/auth/login_screen.dart';
 import 'package:solutions_rent_car/src/screens/home/ClientHomeScreen.dart'; // Ajusta la ruta si es diferente
+import 'package:solutions_rent_car/src/services/notification_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -41,6 +42,7 @@ class MyApp extends StatelessWidget {
     );
 
     await initializeDateFormatting('es', null);
+    await NotificationService.initialize();
   }
 
   @override
@@ -57,6 +59,7 @@ class MyApp extends StatelessWidget {
         final user = FirebaseAuth.instance.currentUser;
 
         return MaterialApp(
+          navigatorKey: navigatorKey,
           debugShowCheckedModeBanner: false,
           theme: ThemeData(useMaterial3: true, primarySwatch: Colors.amber),
           home: user != null ? const ClientHomeScreen() : const LoginScreen(),

--- a/lib/src/screens/auth/login_screen.dart
+++ b/lib/src/screens/auth/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:solutions_rent_car/src/screens/home/ClientHomeScreen.dart';
 import 'package:solutions_rent_car/src/screens/home/SellerHomeScreen.dart';
 import 'package:flutter/foundation.dart'; // asegúrate de tener esto
+import 'package:solutions_rent_car/src/services/notification_service.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -532,6 +533,7 @@ class _LoginScreenState extends State<LoginScreen> {
             MaterialPageRoute(builder: (context) => const ClientHomeScreen()),
           );
         } else if (rol?.toLowerCase() == 'vendedor') {
+          await NotificationService.updateToken(userId);
           Navigator.pushReplacement(
             context,
             MaterialPageRoute(builder: (context) => const SellerHomeScreen()),

--- a/lib/src/screens/home/SellerHomeScreen.dart
+++ b/lib/src/screens/home/SellerHomeScreen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:solutions_rent_car/src/vehiculos/Proveedor/ConfiguraciónEmpresaScreen.dart';
 import 'package:solutions_rent_car/src/vehiculos/Proveedor/MisVehiculosScreen.dart';
+import 'package:solutions_rent_car/src/screens/misrentas/Proveedor/ProveedorRentasScreen.dart';
+import 'package:solutions_rent_car/src/services/notification_service.dart';
 
 class SellerHomeScreen extends StatefulWidget {
   const SellerHomeScreen({super.key});
@@ -18,14 +20,24 @@ class _SellerHomeScreenState extends State<SellerHomeScreen> {
   final Color iconBorderColor = const Color(0xFF9DB2CE);
 
   @override
+  void initState() {
+    super.initState();
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid != null) {
+      NotificationService.updateToken(uid);
+      NotificationService.listenForRentas(uid);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final String userId = FirebaseAuth.instance.currentUser!.uid;
 
     final List<Widget> screens = [
       const Center(child: Text('Bienvenido, Vendedor')),
-      const Center(child: Text('Rentas')),
+      const ProveedorRentasScreen(),
       const MisVehiculosScreen(),
-      ConfiguracionEmpresaScreen(userId: userId), // ✅ Corrección aquí
+      ConfiguracionEmpresaScreen(userId: userId),
     ];
 
     return Theme(

--- a/lib/src/screens/misrentas/Proveedor/ProveedorRentaDetalleScreen.dart
+++ b/lib/src/screens/misrentas/Proveedor/ProveedorRentaDetalleScreen.dart
@@ -1,0 +1,55 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class ProveedorRentaDetalleScreen extends StatelessWidget {
+  final String rentaId;
+
+  const ProveedorRentaDetalleScreen({super.key, required this.rentaId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Detalle de Renta'),
+      ),
+      body: FutureBuilder<DocumentSnapshot>(
+        future: FirebaseFirestore.instance
+            .collection('rentas')
+            .doc(rentaId)
+            .get(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final data = snapshot.data!.data() as Map<String, dynamic>;
+          final fechaInicio = (data['fechaInicio'] as Timestamp).toDate();
+          final fechaFin = (data['fechaFin'] as Timestamp).toDate();
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: ListView(
+              children: [
+                Text(
+                  data['vehiculo'] ?? '',
+                  style: const TextStyle(
+                      fontSize: 22, fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 8),
+                Text('Cliente: ${data['cliente'] ?? ''}'),
+                Text('Tel\u00e9fono: ${data['telefono'] ?? ''}'),
+                const SizedBox(height: 8),
+                Text('Desde ${DateFormat('dd/MM/yyyy HH:mm').format(fechaInicio)}'),
+                Text('Hasta ${DateFormat('dd/MM/yyyy HH:mm').format(fechaFin)}'),
+                const SizedBox(height: 16),
+                Text('Estado: ${data['estado']}'),
+                const SizedBox(height: 16),
+                Text('Total: \$${data['precioTotal']}'),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+

--- a/lib/src/screens/misrentas/Proveedor/ProveedorRentasScreen.dart
+++ b/lib/src/screens/misrentas/Proveedor/ProveedorRentasScreen.dart
@@ -1,63 +1,46 @@
-// lib/src/rentas/ClientRentalsScreen.dart
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:solutions_rent_car/src/screens/misrentas/Cliente/ClienteRentaDetalleScreen.dart';
+import 'ProveedorRentaDetalleScreen.dart';
 
-class Proveedorrentasscreen extends StatelessWidget {
-  const Proveedorrentasscreen({super.key});
+class ProveedorRentasScreen extends StatefulWidget {
+  const ProveedorRentasScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final userId = FirebaseAuth.instance.currentUser?.uid;
+  State<ProveedorRentasScreen> createState() => _ProveedorRentasScreenState();
+}
 
+class _ProveedorRentasScreenState extends State<ProveedorRentasScreen> {
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.grey[50],
       appBar: AppBar(
-        title: const Text("Mis Rentas"),
+        title: const Text('Mis Rentas'),
         centerTitle: true,
-        backgroundColor: Colors.white,
-        foregroundColor: Colors.black,
+        backgroundColor: const Color(0xFFF8A023),
+        foregroundColor: Colors.white,
       ),
       body: StreamBuilder<QuerySnapshot>(
-        stream:
-            FirebaseFirestore.instance
-                .collection('rentas')
-                .where('clienteId', isEqualTo: userId)
-                .orderBy('fechaInicio', descending: true)
-                .snapshots(),
+        stream: FirebaseFirestore.instance
+            .collection('rentas')
+            .orderBy('fechaInicio', descending: true)
+            .snapshots(),
         builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
+          if (!snapshot.hasData) {
             return const Center(child: CircularProgressIndicator());
           }
-
-          final rentas = snapshot.data?.docs ?? [];
-
-          if (rentas.isEmpty) {
-            return const Center(child: Text('No tienes rentas registradas.'));
+          final docs = snapshot.data!.docs;
+          if (docs.isEmpty) {
+            return const Center(child: Text('No hay rentas registradas'));
           }
-
           return ListView.builder(
             padding: const EdgeInsets.all(16),
-            itemCount: rentas.length,
+            itemCount: docs.length,
             itemBuilder: (context, index) {
-              final renta = rentas[index].data() as Map<String, dynamic>;
-              return FutureBuilder<DocumentSnapshot>(
-                future:
-                    FirebaseFirestore.instance
-                        .collection('vehiculos')
-                        .doc(renta['vehiculoId'])
-                        .get(),
-                builder: (context, vehiculoSnapshot) {
-                  if (!vehiculoSnapshot.hasData) return const SizedBox.shrink();
-
-                  final vehiculoData =
-                      vehiculoSnapshot.data!.data() as Map<String, dynamic>?;
-                  final imagenUrl = vehiculoData?['imagenes']?[0] ?? '';
-
-                  return _buildReservaCard(renta, imagenUrl, context);
-                },
-              );
+              final data = docs[index].data() as Map<String, dynamic>;
+              return _buildRentCard(data, docs[index].id, context);
             },
           );
         },
@@ -65,79 +48,105 @@ class Proveedorrentasscreen extends StatelessWidget {
     );
   }
 
-  Widget _buildReservaCard(
-    Map<String, dynamic> data,
-    String imagenUrl,
+  Widget _buildRentCard(
+    Map<String, dynamic> rentData,
+    String idReserva,
     BuildContext context,
   ) {
-    final fechaInicio = (data["fechaInicio"] as Timestamp).toDate();
-    final fechaFin = (data["fechaFin"] as Timestamp).toDate();
+    final fechaInicio = (rentData['fechaInicio'] as Timestamp).toDate();
+    final fechaFin = (rentData['fechaFin'] as Timestamp).toDate();
     final fechaInicioStr = DateFormat('M/d/yyyy').format(fechaInicio);
     final fechaFinStr = DateFormat('M/d/yyyy').format(fechaFin);
+    final estado = rentData['estado'] ?? 'Pendiente';
 
     return GestureDetector(
       onTap: () {
-        Navigator.push(
-          context,
+        Navigator.of(context).push(
           MaterialPageRoute(
-            builder:
-                (_) => ClienteRentaDetallesScreen(
-                  rentaData: data,
-                  imagenUrl: imagenUrl,
-                  idRenta: data['id'],
-                ),
+            builder: (_) => ProveedorRentaDetalleScreen(rentaId: idReserva),
           ),
         );
       },
-      child: Card(
-        margin: const EdgeInsets.only(bottom: 20),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        elevation: 2,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.08),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (imagenUrl.isNotEmpty)
+            if ((rentData['imagen'] ?? '').toString().isNotEmpty)
               ClipRRect(
-                borderRadius: const BorderRadius.vertical(
-                  top: Radius.circular(12),
-                ),
+                borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
                 child: Image.network(
-                  imagenUrl,
-                  height: 180,
+                  rentData['imagen'],
+                  height: 200,
                   width: double.infinity,
                   fit: BoxFit.cover,
+                  errorBuilder: (c, o, s) => Container(
+                    height: 200,
+                    color: Colors.grey[200],
+                    child: const Icon(Icons.directions_car, size: 50, color: Colors.grey),
+                  ),
                 ),
               ),
             Padding(
-              padding: const EdgeInsets.all(12),
+              padding: const EdgeInsets.all(16),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    data["vehiculo"] ?? '',
-                    style: const TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text("Desde $fechaInicioStr hasta $fechaFinStr"),
-                  const SizedBox(height: 8),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
+                      Expanded(
+                        child: Text(
+                          rentData['vehiculo'] ?? 'Veh\u00edculo',
+                          style: const TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
                       Text(
-                        "\$${data["precioTotal"].toStringAsFixed(2)}",
+                        '\$${(rentData['precioTotal'] ?? 0).toStringAsFixed(2)}',
                         style: const TextStyle(
-                          fontSize: 16,
+                          fontSize: 20,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
-                      Chip(
-                        label: Text(data["estado"] ?? ''),
-                        backgroundColor: Colors.orange.shade200,
-                        labelStyle: const TextStyle(color: Colors.black),
-                      ),
                     ],
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Desde $fechaInicioStr hasta $fechaFinStr',
+                    style: TextStyle(fontSize: 14, color: Colors.grey[600]),
+                  ),
+                  const SizedBox(height: 12),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      decoration: BoxDecoration(
+                        color: _statusColor(estado),
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Text(
+                        estado,
+                        style: TextStyle(
+                          color: _statusTextColor(estado),
+                          fontWeight: FontWeight.w600,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ),
                   ),
                 ],
               ),
@@ -146,5 +155,33 @@ class Proveedorrentasscreen extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Color _statusColor(String status) {
+    switch (status.toLowerCase()) {
+      case 'confirmada':
+      case 'activa':
+        return Colors.green[100]!;
+      case 'pendiente':
+        return Colors.orange[100]!;
+      case 'cancelada':
+        return Colors.red[100]!;
+      default:
+        return Colors.grey[200]!;
+    }
+  }
+
+  Color _statusTextColor(String status) {
+    switch (status.toLowerCase()) {
+      case 'confirmada':
+      case 'activa':
+        return Colors.green[700]!;
+      case 'pendiente':
+        return Colors.orange[700]!;
+      case 'cancelada':
+        return Colors.red[700]!;
+      default:
+        return Colors.black54;
+    }
   }
 }

--- a/lib/src/services/notification_service.dart
+++ b/lib/src/services/notification_service.dart
@@ -1,0 +1,93 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import '../screens/misrentas/Proveedor/ProveedorRentaDetalleScreen.dart';
+
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+class NotificationService {
+  static final FirebaseMessaging _messaging = FirebaseMessaging.instance;
+  static final FlutterLocalNotificationsPlugin _localNotifications =
+      FlutterLocalNotificationsPlugin();
+  static StreamSubscription<QuerySnapshot>? _rentaSub;
+
+  static Future<void> initialize() async {
+    await _messaging.requestPermission();
+
+    const initSettings = InitializationSettings(
+      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+    );
+    await _localNotifications.initialize(initSettings,
+        onDidReceiveNotificationResponse: (details) {
+      final payload = details.payload;
+      if (payload != null) {
+        navigatorKey.currentState?.push(
+          MaterialPageRoute(
+            builder: (_) => ProveedorRentaDetalleScreen(rentaId: payload),
+          ),
+        );
+      }
+    });
+
+    FirebaseMessaging.onMessage.listen(_handleMessage);
+    FirebaseMessaging.onMessageOpenedApp.listen(_handleMessage);
+  }
+
+  static Future<void> _handleMessage(RemoteMessage message) async {
+    final rentaId = message.data['rentaId'];
+    await _localNotifications.show(
+      message.hashCode,
+      message.notification?.title,
+      message.notification?.body,
+      const NotificationDetails(
+        android: AndroidNotificationDetails(
+          'rentas',
+          'Rentas',
+          importance: Importance.max,
+          priority: Priority.high,
+        ),
+      ),
+      payload: rentaId,
+    );
+  }
+
+  static Future<void> updateToken(String userId) async {
+    final token = await _messaging.getToken();
+    if (token != null) {
+      await FirebaseFirestore.instance
+          .collection('usuarios')
+          .doc(userId)
+          .update({'fcmToken': token});
+    }
+  }
+
+  static void listenForRentas(String userId) {
+    _rentaSub?.cancel();
+    _rentaSub = FirebaseFirestore.instance
+        .collection('rentas')
+        .orderBy('fechaCreacion', descending: true)
+        .snapshots()
+        .listen((snapshot) {
+      for (var change in snapshot.docChanges) {
+        if (change.type == DocumentChangeType.added) {
+          final data = change.doc.data() as Map<String, dynamic>;
+          _localNotifications.show(
+            change.doc.hashCode,
+            'Nueva renta',
+            data['vehiculo'] ?? 'Nueva renta registrada',
+            const NotificationDetails(
+              android: AndroidNotificationDetails(
+                'rentas',
+                'Rentas',
+                importance: Importance.max,
+                priority: Priority.high,
+              ),
+            ),
+            payload: change.doc.id,
+          );
+        }
+      }
+    });
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,8 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
+  firebase_messaging: ^14.7.10
+  flutter_local_notifications: ^16.2.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary
- add Firebase messaging and local notifications dependencies
- implement NotificationService with Firestore listener
- create provider rent detail screen
- redesign provider rents list screen
- integrate notifications in SellerHome and login
- set up navigator key and initialize service in main

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e6211568832795918dd889871b20