### PR TITLE
Implement simple notification service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:solutions_rent_car/firebase_options.dart';
 import 'package:solutions_rent_car/src/screens/auth/register_screen.dart';
 import 'package:solutions_rent_car/src/screens/auth/login_screen.dart';
 import 'package:solutions_rent_car/src/screens/home/ClientHomeScreen.dart'; // Ajusta la ruta si es diferente
+import 'package:solutions_rent_car/src/services/notification_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -41,6 +42,7 @@ class MyApp extends StatelessWidget {
     );
 
     await initializeDateFormatting('es', null);
+    await NotificationService().init();
   }
 
   @override

--- a/lib/src/services/notification_service.dart
+++ b/lib/src/services/notification_service.dart
@@ -1,0 +1,60 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+class NotificationService {
+  NotificationService._internal();
+  static final NotificationService _instance = NotificationService._internal();
+  factory NotificationService() => _instance;
+
+  final FirebaseMessaging _messaging = FirebaseMessaging.instance;
+  final FlutterLocalNotificationsPlugin _localNotificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+
+  String? _lastMessageId;
+
+  Future<void> init() async {
+    await _messaging.requestPermission();
+
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const settings = InitializationSettings(android: androidSettings);
+    await _localNotificationsPlugin.initialize(settings);
+
+    FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+    FirebaseMessaging.onMessage.listen(_onMessage);
+  }
+
+  Future<void> _onMessage(RemoteMessage message) async {
+    await _showNotification(message);
+  }
+
+  @pragma('vm:entry-point')
+  static Future<void> _firebaseMessagingBackgroundHandler(
+      RemoteMessage message) async {
+    await NotificationService()._showNotification(message);
+  }
+
+  Future<void> _showNotification(RemoteMessage message) async {
+    if (message.messageId != null && message.messageId == _lastMessageId) {
+      return;
+    }
+    _lastMessageId = message.messageId;
+
+    final notification = message.notification;
+    if (notification != null) {
+      const details = NotificationDetails(
+        android: AndroidNotificationDetails(
+          'default_channel',
+          'Notifications',
+          importance: Importance.max,
+          priority: Priority.high,
+        ),
+      );
+      await _localNotificationsPlugin.show(
+        0,
+        notification.title,
+        notification.body,
+        details,
+      );
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,8 @@ dependencies:
   android_intent_plus: ^5.3.0
   cached_network_image: ^3.4.1
   table_calendar: ^3.2.0
+  firebase_messaging: ^14.7.10
+  flutter_local_notifications: ^15.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `notification_service.dart` to handle Firebase Messaging and local notifications
- init notification service in `main.dart`
- add `firebase_messaging` and `flutter_local_notifications` dependencies

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a001127d08327a7d6bc7a7a81dfcf