### PR TITLE
Implement provider notification via FCM

### DIFF
--- a/lib/src/screens/auth/login_screen.dart
+++ b/lib/src/screens/auth/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:solutions_rent_car/src/screens/home/ClientHomeScreen.dart';
 import 'package:solutions_rent_car/src/screens/home/SellerHomeScreen.dart';
+import 'package:solutions_rent_car/src/services/notification_service.dart';
 import 'package:flutter/foundation.dart'; // asegúrate de tener esto
 
 class LoginScreen extends StatefulWidget {
@@ -532,6 +533,7 @@ class _LoginScreenState extends State<LoginScreen> {
             MaterialPageRoute(builder: (context) => const ClientHomeScreen()),
           );
         } else if (rol?.toLowerCase() == 'vendedor') {
+          await NotificationService().subscribeToTopic('providers');
           Navigator.pushReplacement(
             context,
             MaterialPageRoute(builder: (context) => const SellerHomeScreen()),

--- a/lib/src/screens/misrentas/Proveedor/ProveedorRentaDetalleScreen.dart
+++ b/lib/src/screens/misrentas/Proveedor/ProveedorRentaDetalleScreen.dart
@@ -20,8 +20,9 @@ class ProveedorRentaDetallesScreen extends StatelessWidget {
     final fechaInicio = (rentaData['fechaInicio'] as Timestamp).toDate();
     final fechaFin = (rentaData['fechaFin'] as Timestamp).toDate();
     final estado = (rentaData['estado'] ?? '').toString().toLowerCase();
-    final puedeAccionar =
-        estado == 'pendiente' || estado == 'cancelacion_pendiente';
+    final puedeAccionar = estado == 'pendiente' ||
+        estado == 'cancelacion_pendiente' ||
+        estado == 'pre-agendada';
 
     return Scaffold(
       backgroundColor: Colors.grey[50],

--- a/lib/src/screens/rentas/ConfirmacionReservaScreen.dart
+++ b/lib/src/screens/rentas/ConfirmacionReservaScreen.dart
@@ -6,6 +6,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:solutions_rent_car/src/screens/home/ClientHomeScreen.dart';
+import 'package:solutions_rent_car/src/services/fcm_service.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'dart:math';
 
@@ -42,6 +43,7 @@ class _ConfirmacionReservaScreenState extends State<ConfirmacionReservaScreen> {
   bool isLoading = true;
   Map<String, dynamic>? vehiculoData;
   String? errorMessage;
+  bool _notificationSent = false;
 
   @override
   void initState() {
@@ -795,6 +797,11 @@ class _ConfirmacionReservaScreenState extends State<ConfirmacionReservaScreen> {
       };
 
       await FirebaseFirestore.instance.collection('rentas').add(reserva);
+
+      if (!_notificationSent) {
+        _notificationSent = true;
+        await FcmService.sendNewRentalNotification(reserva);
+      }
 
       // También actualizar el contador de reservas del vehículo
       final docRef =

--- a/lib/src/services/fcm_service.dart
+++ b/lib/src/services/fcm_service.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class FcmService {
+  FcmService._();
+
+  static const String _serverKey = String.fromEnvironment('FCM_SERVER_KEY');
+  static const String _fcmUrl = 'https://fcm.googleapis.com/fcm/send';
+
+  static Future<void> sendNewRentalNotification(
+      Map<String, dynamic> renta) async {
+    if (_serverKey.isEmpty) return;
+
+    final message = {
+      'to': '/topics/providers',
+      'notification': {
+        'title': 'Nueva renta',
+        'body': 'Se ha creado una renta de ${renta['vehiculo'] ?? ''}',
+      },
+      'data': {
+        'idReserva': renta['idReserva'] ?? '',
+      }
+    };
+
+    try {
+      await http.post(
+        Uri.parse(_fcmUrl),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'key=$_serverKey',
+        },
+        body: jsonEncode(message),
+      );
+    } catch (_) {
+      // Silenciar errores en el envío de notificaciones
+    }
+  }
+}
+

--- a/lib/src/services/notification_service.dart
+++ b/lib/src/services/notification_service.dart
@@ -23,6 +23,14 @@ class NotificationService {
     FirebaseMessaging.onMessage.listen(_onMessage);
   }
 
+  Future<void> subscribeToTopic(String topic) async {
+    await _messaging.subscribeToTopic(topic);
+  }
+
+  Future<void> unsubscribeFromTopic(String topic) async {
+    await _messaging.unsubscribeFromTopic(topic);
+  }
+
   Future<void> _onMessage(RemoteMessage message) async {
     await _showNotification(message);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   table_calendar: ^3.2.0
   firebase_messaging: ^15.2.7
   flutter_local_notifications: ^19.2.1
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- subscribe vendors to an FCM topic after login
- send FCM message when a rental is created
- allow providers to confirm/cancel rentals in "pre‑agendada" status
- add FCM sender utility and extra helper methods
- add `http` dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b52c165e88327af2ad2b258f49cb6